### PR TITLE
Add Project Dependency Injection and Create DI Module to Core Domain

### DIFF
--- a/AbcCompany.sln
+++ b/AbcCompany.sln
@@ -11,6 +11,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{1ACB5D63-7
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AbcCompany.Core.Domain", "Source\AbcCompany.Core.Domain\AbcCompany.Core.Domain.csproj", "{BBFAAAC1-2AD2-40F1-AFAD-70CA6305D852}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DependencyInjection", "DependencyInjection", "{572EF21E-3FC8-4078-B437-F94D3725EFBA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AbcCompany.DependencyInjection", "Source\AbcCompany.DependencyInjection\AbcCompany.DependencyInjection.csproj", "{3E765A19-B6BD-4F61-8F53-E77CEA4DFFBB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AbcCompany.Core.DependencyInjection", "Source\AbcCompany.Core.DependencyInjection\AbcCompany.Core.DependencyInjection.csproj", "{B1EDEDAF-EE7F-4CA4-9059-8AFD612E8D2B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +27,14 @@ Global
 		{BBFAAAC1-2AD2-40F1-AFAD-70CA6305D852}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BBFAAAC1-2AD2-40F1-AFAD-70CA6305D852}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BBFAAAC1-2AD2-40F1-AFAD-70CA6305D852}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E765A19-B6BD-4F61-8F53-E77CEA4DFFBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E765A19-B6BD-4F61-8F53-E77CEA4DFFBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E765A19-B6BD-4F61-8F53-E77CEA4DFFBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E765A19-B6BD-4F61-8F53-E77CEA4DFFBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1EDEDAF-EE7F-4CA4-9059-8AFD612E8D2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1EDEDAF-EE7F-4CA4-9059-8AFD612E8D2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1EDEDAF-EE7F-4CA4-9059-8AFD612E8D2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1EDEDAF-EE7F-4CA4-9059-8AFD612E8D2B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -28,6 +42,9 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{1ACB5D63-76AF-4015-B09D-0963C5AE6E43} = {5E39E15B-7A27-4F38-85BB-89BC6DF295C3}
 		{BBFAAAC1-2AD2-40F1-AFAD-70CA6305D852} = {1ACB5D63-76AF-4015-B09D-0963C5AE6E43}
+		{572EF21E-3FC8-4078-B437-F94D3725EFBA} = {5E39E15B-7A27-4F38-85BB-89BC6DF295C3}
+		{3E765A19-B6BD-4F61-8F53-E77CEA4DFFBB} = {572EF21E-3FC8-4078-B437-F94D3725EFBA}
+		{B1EDEDAF-EE7F-4CA4-9059-8AFD612E8D2B} = {1ACB5D63-76AF-4015-B09D-0963C5AE6E43}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {791FB17E-3F3B-4E9F-91BC-4C1ADD32A7FB}

--- a/Source/AbcCompany.Core.DependencyInjection/AbcCompany.Core.DependencyInjection.csproj
+++ b/Source/AbcCompany.Core.DependencyInjection/AbcCompany.Core.DependencyInjection.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AbcCompany.Core.Domain\AbcCompany.Core.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/AbcCompany.Core.DependencyInjection/CoreDependencyInjection.cs
+++ b/Source/AbcCompany.Core.DependencyInjection/CoreDependencyInjection.cs
@@ -1,0 +1,27 @@
+﻿using AbcCompany.Core.Domain.Configuration;
+using AbcCompany.Core.Domain.Data;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AbcCompany.Core.DependencyInjection
+{
+    public static class CoreDependencyInjection
+    {
+
+        public static void AddDependencyInjectionCoreModule(this IServiceCollection services, IConfiguration configuration)
+        {
+            if (services == null) throw new ArgumentNullException(nameof(services));
+
+            services.AddDomainServicesCore(configuration);
+        }
+
+        private static void AddDomainServicesCore(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddSingleton<Settings>(x => configuration.Get<Settings>());
+
+            services.AddScoped<DbContext>();
+            services.AddScoped<DbFactory>();
+        }
+
+    }
+}

--- a/Source/AbcCompany.DependencyInjection/AbcCompany.DependencyInjection.csproj
+++ b/Source/AbcCompany.DependencyInjection/AbcCompany.DependencyInjection.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Setup\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AbcCompany.Core.DependencyInjection\AbcCompany.Core.DependencyInjection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/AbcCompany.DependencyInjection/DependencyInjectionServices.cs
+++ b/Source/AbcCompany.DependencyInjection/DependencyInjectionServices.cs
@@ -1,0 +1,20 @@
+﻿using AbcCompany.Core.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AbcCompany.DependencyInjection
+{
+    public static class DependencyInjectionServices
+    {
+        public static void RegisterServices(this IServiceCollection services, IConfiguration configuration)
+        {
+
+            services.AddDependencyInjectionCoreModule(configuration);
+
+        }
+
+
+
+    }
+
+}


### PR DESCRIPTION
1. Add Project Dependency Injection 
2. Create DI Module to Core Domain

I gonna create DI Module for each Domain, to simply new merge when this application grow more. So more easy to add services in DI and rare to conflit when multiples work same time in this project